### PR TITLE
docs: 프로미스 체이닝 심층 연습 노트 추가

### DIFF
--- a/deep-practice/promise-chaining.md
+++ b/deep-practice/promise-chaining.md
@@ -233,3 +233,45 @@ promise2 -> setTimeout -> then
 > 실행 결과가 이렇게 된 것은 마이크로태스크 큐의 우선순위가 태스크 큐보다 높기 때문입니다. 또한 후속처리메서드들의 콜백함수는 바로 실행되는 것이 아니라 마이크로태스큐에서 대기합니다. 콜스택이 비어있을 때 마이크로태스크 큐를 확인하여 작업이 있을 경우 콜스택에 넣어 함수를 실행합니다. 마이크로태스크 큐도 비어져있다면 태스크 큐를 확인하여 작업이 있을 경우 콜스택에 넣어 함수를 실행합니다.
 >
 > 즉, 동기 코드들과 `Promise` 생성 코드를 실행 → `Promise`의 후속 처리 메서드의 콜백함수 실행 → `setTimeout`의 콜백함수를 실행하는 것을 알 수 있습니다.
+
+Q. 콜백함수를 이용한 비동기 처리 방식과 비교했을 때 프로미스 체이닝은 어떤 장점이 있나요?
+
+> 콜백 헬이 발생하지 않습니다.
+>
+> 프로미스 체이닝은 콜백함수를 첨부하는 방식입니다. 그래서 코드가 중첩되지 않기 때문에 콜백 헬이 발생하지 않습니다. 비동기 동작을 추가해도 아래로 코드가 길어질 뿐 오른쪽으로 코드가 깊어지지 않습니다.
+
+> 에러 핸들링이 간편합니다.
+>
+> 콜백함수를 이용해서 비동기 처리를 할 경우, 에러를 핸들링하기 위한 코드를 매번 다음 콜백함수로 계속해서 전달해줘야 했습니다. 하지만 프로미스 체이닝을 이용하면 중복적으로 에러 핸들링을 하지 않아도 된다는 장점이 있습니다. 에러가 발생하면 체인 아래의 `catch`를 찾기 때문에 이 특성을 사용하면 중복으로 에러 핸들링을 하지 않아도 됩니다. 아래는 콜백 기반으로 처리할 경우의 예시입니다.
+
+```js
+doSomething(function (result) {
+  doSomethingElse(
+    result,
+    function (newResult) {
+      doThirdThing(
+        newResult,
+        function (finalResult) {
+          console.log("Got the final result: " + finalResult);
+        },
+        failureCallback
+      );
+    },
+    failureCallback
+  );
+}, failureCallback);
+```
+
+> 콜백기반으로 비동기 처리를 할 경우 에러처리콜백을 매번 전달해주는 것을 알 수 있습니다.
+
+> 아래는 프로미스로 처리할 경우의 예시입니다.
+
+```js
+doSomething() // *
+  .then((result) => doSomethingElse(result)) // **
+  .then((newResult) => doThirdThing(newResult)) // ***
+  .then((finalResult) => console.log(`Got the final result: ${finalResult}`)) // ****
+  .catch(failureCallback);
+```
+
+> \*~ \*\*\*\*에 대한 에러 핸들링 코드가 동일하다면 위의 예시처럼 `catch`를 뒤에 한번만 위치시키면 에러를 처리할 수 있습니다.

--- a/deep-practice/promise-chaining.md
+++ b/deep-practice/promise-chaining.md
@@ -1,0 +1,169 @@
+# Promise Chaining
+
+Q. 프로미스 체이닝이 무엇인가요?
+
+> 프로미스 체이닝이란 여러 개의 `then`메서드를 체인처럼 연결하여 비동기 작업을 순차적으로 처리하는 방식을 말합니다. 프로미스 체이닝의 예시입니다.
+
+```js
+new Promise(function (resolve, reject) {
+  setTimeout(() => resolve(1), 1000); // (*)
+})
+  .then(function (result) {
+    alert(result); // 1
+    return result * 2;
+  })
+  .then(function (result) {
+    alert(result); // 2
+    return result * 2;
+  })
+  .then(function (result) {
+    alert(result); // 4
+    return result * 2;
+  });
+```
+
+> 이렇게 `then`메서드를 체인처럼 연결하면, 비동기 작업을 순차적으로 처리하며 결과값을 순차적으로 전달할 수 있습니다.
+
+Q. 프로미스 체이닝은 주로 어떤 상황에 사용하나요?
+
+> 2개 이상의 비동기 작업을 순차적으로 실행해야 할 경우 사용합니다. 즉, 어떤 비동기 작업의 결과값을 이용해서 다음 비동기 작업에 실행해야 하는 상황에 프로미스 체이닝을 사용하여 해결할 수 있습니다.
+>
+> `fetch`메서드를 사용해서 예시를 들어보겠습니다. `fetch`는 네트워크 요청을 보낼 url을 인수로 받습니다. `fetch`를 호출하면 서버에서 response객체를 응답받으며 이행된 프로미스를 반환합니다.
+
+```js
+// 1. 서버에 요청을 보냅니다.
+fetch("/article/promise-chaining/user.json")
+  // 2. 서버로부터 응답받은 내용을 json으로 불러옵니다.
+  .then((response) => response.json())
+  // 3. 불러온 사용자 정보로 그 사용자의 github 프로필을 받아오기 위해 요청을 보내겠습니다.
+  .then((user) => fetch(`https://api.github.com/users/${user.name}`))
+  // 4. 서버로부터 응답받은 내용을 json으로 불러옵니다.
+  .then((response) => response.json())
+  // 5. 받아온 github 프로필 정보로 3초동안 프로필 이미지를 보여주겠습니다.
+  .then(
+    (githubUser) =>
+      new Promise(function (resolve, reject) {
+        // (*)
+        let img = document.createElement("img");
+        img.src = githubUser.avatar_url;
+        img.className = "promise-avatar-example";
+        document.body.append(img);
+
+        setTimeout(() => {
+          img.remove();
+          resolve(githubUser); // (**)
+        }, 3000);
+      })
+  )
+  // 6. 3초 후에 alert창이 뜹니다.
+  .then((githubUser) =>
+    alert(`${githubUser.name}의 이미지를 성공적으로 출력하였습니다.`)
+  );
+```
+
+> 이렇게 여러개의 비동기 작업을 순차적으로 해야하며 이전 결과값이 다음 비동기 작업에 필요할 경우 프로미스 체이닝으로 구현할 수 있습니다.
+
+Q. 프로미스 체이닝은 어떻게 가능한건가요?
+
+> `then`메서드를 포함한 `catch`, `finally` 메서드는 새로운 `Promise`객체를 반환하기 때문입니다. `then`메서드는 `Promise`객체를 반환하고, `Promise`에는 `then`메서드를 호출할 수 있기 때문에 체이닝이 가능합니다.
+
+Q. `then`메서드에서 return한 값은 어떻게 다음 `then`메서드에 전달되는건가요?
+
+> `then`메서드의 콜백함수는 일반 값을 반환할 수도 있고 `Promise` 객체를 생성하여 반환할 수도 있습니다. 일반 값을 반환하더라도 결국에는 `Promise`객체를 생성하여 반환하게 됩니다. 즉, `Promise.resovle(일반 값)`으로 처리됩니다.
+>
+> 다음은 경우에 따라 어떤 `Promise`객체를 반환하는지 정리한 것입니다.
+
+- 값을 반환하는 경우
+  - `state`: `fulfilled`, `result`: 값
+  - `then`메서드의 첫번째 인수(프로미스가 `fulfilled`되었을 때 실행되는 함수)를 실행합니다.
+- `return`문이 없을 경우
+  - `state`: `fulfilled`, `result`: `undefined`
+  - `then`메서드의 첫번째 인수(프로미스가 `fulfilled`되었을 때 실행되는 함수)를 실행합니다.
+- `throw error`인 경우
+  - `state`: `rejected`, `result`: `throw한 error`
+  - `then`메서드의 두번째 인수(프로미스가 `rejected`되었을 때 실행되는 함수)를 실행합니다.
+- `fulfilled` 상태인 `promise`를 반환하는 경우
+  - `state`: `fulfilled`, `result`: `반환한 promise의 result`
+  - `then`메서드의 첫번째 인수(프로미스가 `fulfilled`되었을 때 실행되는 함수)를 실행합니다.
+- `reject` 상태인 `promise`를 반환하는 경우
+  - `state`: `rejected`, `result`: `반환한 promise의 result`
+  - `then`메서드의 두번째 인수(프로미스가 `rejected`되었을 때 실행되는 함수)를 실행합니다.
+- `pending` 상태인 `promise`를 반환하는 경우
+  - `promise`가 처리되기를 (`fulfilled`되거나 `rejected`) 기다렸다가 완료되면 그 `promise`를 반환한다.
+  - `promise` 처리결과에 따라 `then`메서드의 첫번째 인수나 두번째 인수가 실행됩니다.
+  - 아래는 예시입니다.
+
+```js
+new Promise(function (resolve, reject) {
+  setTimeout(() => resolve(1), 1000);
+})
+  .then(function (result) {
+    alert(result); // 1
+    return new Promise((resolve, reject) => {
+      // (*) resolve를 호출하면 **를 실행합니다.
+      setTimeout(() => resolve(result * 2), 1000);
+    });
+  })
+  .then(function (result) {
+    // (**)
+    alert(result); // 2
+  });
+```
+
+> 따라서 각 경우에 따라 위의 `state`와 `result`인 `Promise`객체를 반환하게 됩니다.
+
+Q. 연결된 여러개의 `then`메서드들의 콜백함수들은 모두 차례대로 실행되나요?
+
+> 네, 앞의 `then`메서드부터 차례대로 실행되지만 주의해야할 점이 있습니다.
+>
+> 각각의 콜백함수들은 `return`문이 있어야 합니다. 그렇지 않으면 다음 `then`메서드들의 콜백함수들이 인자를 받지 못합니다.
+
+```js
+new Promise((resolve, reject) => {
+  resolve(1);
+})
+  .then(function (result) {
+    // (*)
+    alert(result); // 1
+    result *= 2;
+  })
+  .then(function (result) {
+    // (**)
+    alert(result); // undefined
+  });
+```
+
+> 위의 예시에서 첫번째 `then`메서드에 `return`문이 없기 때문에 두번째 `then`메서드는 인자를 받지 못해 `undefined`를 출력합니다.
+>
+> 두번째로 주의해야 할 점은 콜백함수 내부에 비동기 작업이 있을 경우에는 `Promise` 객체를 생성하여 반환해야합니다. `fetch`메서드의 경우 반환값이 `Promise`객체이기 때문에 자체로 `Promise`객체를 반환하는 메서드는 상관없지만, 예를 들어 `setTimeout`함수를 사용할 경우 새로운 프로미스 객체를 생성하여 반환해야 순차적으로 처리할 수 있습니다.
+
+```js
+Promise.resolve(1)
+  .then((result) => {
+    setTimeout(() => alert("첫번째 then : " + result), 3000); // (*)
+    return result * 2;
+  })
+  // 3초 후에 *의 alert창을 실행한 후가 아닌 그보다 먼저 실행됩니다.
+  .then((result) => alert("두번째 then : " + result)); // 1
+```
+
+> 위의 예시에서 3초 후에 첫번째 `then`메서드의 `alert`창이 먼저 실행된 후에 두번째 `then`메서드의 `alert`창을 실행하는 게 아니라, 두번째 `alert`창 실행 → 첫번째 `alert`창 실행의 순서로 이루어진 것을 알 수 있습니다.
+
+```js
+Promise.resolve(1)
+  .then(
+    (result) =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          alert("첫번째 then : " + result);
+          resolve(result * 2);
+        }, 3000);
+      })
+  )
+  // 첫번째 alert창 이후에 순차적으로 두번째 alert창이 실행됩니다.
+  .then((result) => alert("두번째 then : " + result)); // 1
+```
+
+> `setTimeout`을 호출하면 `setTimeout`의 콜백함수는 콜백 큐에 담겨져 대기합니다. 그리고 다음 코드들을 실행합니다. 콜백함수는 콜 스택이 비워진 다음에야 호출됩니다. 그렇기 때문에 콜백함수의 실행을 기다리지 않고 다음 `then`메서드를 실행한 것입니다.
+>
+> `setTimeout`의 콜백함수를 수행한 다음에 이후의 `then`메서드를 순차적으로 실행하고 싶은 경우, `Promise`를 생성하여 내부에서 `setTimeout`을 호출하도록 해야합니다. 이렇게 하면 `Promise`객체는 객체가 처리되길 기다려야하기 때문에 콜백함수에서 모든 동작 이후에 `resolve`를 호출하면 다음 `then`메서드로 넘어갑니다.


### PR DESCRIPTION
# 어떤 내용이었는지 요약해주세요.

- 프로미스 체이닝을 이용하면 `then`메서드를 체인처럼 연결하여 비동기 작업과 후속 작업을 순차적으로 처리할 수 있습니다.

# 이번 학습을 통해 본인에게 무엇이 달라졌나요?

- 프로미스 체이닝으로 순차적으로 비동기 작업과 여러 작업을 처리할 수 있습니다.
- `then`메서드가 어떻게 동작하는지 설명할 수 있습니다.
  - `then`메서드는 프로미스 객체를 반환하기에 체이닝이 가능합니다.
  - 또한 `then`메서드에서 비동기 작업을 수행할 경우 프로미스를 생성하여 반환해야 작업 순서를 보장할 수 있습니다.
- 이번에 공부를 하기 전에는 `then`메서드는 내부에 비동기 동작이 있을 경우 무조건 그 동작이 완료된 이후에 다음 `then`메서드로 넘어가는지 알고 있었습니다.
  - 기존에는 `then`메서드의 특성상 무조건 내부의 동작이 완료된 후에 다음 `then`메서드로 넘어가는지 알았습니다.
  - 하지만 `setTimeout`함수를 이용한 예제를 통해 `Promise`객체를 반환해야만 비동기 작업의 처리를 보장한다는 점을 알게 되었습니다.

# 여전히 잘 모르겠거나 궁금한 점을 모두 적어주세요

- [Promise rejection events](https://developer.mozilla.org/ko/docs/Web/JavaScript/Guide/Using_promises#promise_rejection_events)의 개념에 대해서도 잘 이해가 가지 않고 이 이벤트를 활용하는 상황은 어떤 상황인지 잘 모르겠습니다.
- [오래된 콜백 API를 이용한 Promise만들기](https://developer.mozilla.org/ko/docs/Web/JavaScript/Guide/Using_promises#%EC%98%A4%EB%9E%98%EB%90%9C_%EC%BD%9C%EB%B0%B1_api%EB%A5%BC_%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC_promise%EB%A7%8C%EB%93%A4%EA%B8%B0) 부분을 이해하지 못해서 무슨 내용인지 궁금합니다. 

# 보완할 점

- 아직 다 완성하지 못해서 마지막 질문에 대한 답변을 추가하려고 합니다.
- 콜백함수를 이용한 비동기 처리보다 프로미스 체이닝을 이용했을 때의 장점을 추가하고 싶습니다.
- 프로미스의 콜백함수는 마이크로태스크 큐로 처리되고 `setTimeout`의 콜백은 콜백큐로 처리되는데 이에 따른 실행 순서에 대한 부분을 추가하고 싶습니다.
